### PR TITLE
Add Binding Unit Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axe-webdriverio",
   "description": "Provides a method to integrate axe with webdriverio to inject and analyze web pages using aXe",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "main": "lib/index.js",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -27,11 +27,15 @@
     "webdriverio"
   ],
   "scripts": {
+    "test": "jest"
   },
   "peerDependencies": {
     "webdriverio": ">= 4.10.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "jest": "^24.3.0",
+    "webdriverio": ">= 4.10.0"
+  },
   "dependencies": {
     "axe-webdriverjs": "^1.2.1"
   }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,38 @@
+const bindings = require("../lib/bindings");
+const { remote } = require("webdriverio");
+
+let browser = {};
+
+beforeEach(() => {
+  browser = {
+    execute: () => {},
+    executeAsync: () => {},
+    frame: () => {},
+    elements: () => {}
+  };
+});
+
+describe("WebDriverIO Builder", () => {
+  describe("Binding", () => {
+    test("Should bind executeScript", async () => {
+      expect(browser.executeScript).toBeUndefined();
+      const boundBrowser = bindings(browser);
+      expect(boundBrowser.executeScript).not.toBeUndefined();
+    });
+    test("Should bind executeAsyncScript", async () => {
+      expect(browser.executeAsyncScript).toBeUndefined();
+      const boundBrowser = bindings(browser);
+      expect(boundBrowser.executeAsyncScript).not.toBeUndefined();
+    });
+    test("Should bind switchTo", async () => {
+      expect(browser.switchTo).toBeUndefined();
+      const boundBrowser = bindings(browser);
+      expect(boundBrowser.switchTo).not.toBeUndefined();
+    });
+    test("Should bind findElements", async () => {
+      expect(browser.findElements).toBeUndefined();
+      const boundBrowser = bindings(browser);
+      expect(boundBrowser.findElements).not.toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Added tests to this package using Jest. Tests validate bindings exist for each of the functions used by `axe-webdriverjs`.

This is very basic functionality, but I felt these tests are fundamental to making sure it'll work with `axe-webdriverjs`. In the future it would be nice to add some tests using `webdriverio` and getting Axe analysis. I can look into that once `axe-webdriverjs` is a peer dependency.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen