### PR TITLE
Add TypeScript Support

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,4 @@
+declare module "axe-webdriverio" {
+  export * from "axe-webdriverjs";
+  export { AxeBuilder as AxeWebDriverIOBuilder } from "axe-webdriverjs";
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   "peerDependencies": {
     "webdriverio": ">= 4.10.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@types/axe-webdriverjs": "^2.0.0"
+  },
   "dependencies": {
     "axe-webdriverjs": "^1.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "axe-webdriverio",
   "description": "Provides a method to integrate axe with webdriverio to inject and analyze web pages using aXe",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "license": "MIT",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "contributors": [
     {
       "name": "Sushil Nagi",
@@ -26,13 +27,15 @@
     "webdriver",
     "webdriverio"
   ],
-  "scripts": {
-  },
+  "scripts": {},
   "peerDependencies": {
     "webdriverio": ">= 4.10.0"
   },
   "devDependencies": {},
   "dependencies": {
     "axe-webdriverjs": "^1.2.1"
+  },
+  "optionalDependencies": {
+    "@types/axe-webdriverjs": "^2.0.0"
   }
 }


### PR DESCRIPTION
Add types to this package. This is done by making `@types/axe-webdriverjs` an optional dependency so only people using TypeScript need to include that.

I'm open to discussion about this since I've been told people are wary of maintaining types, but since this types file should never change I felt it made sense to include with the package.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen