### PR TITLE
Make axe-webdriverjs a Peer Dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ typings/
 # dotenv environment variables file
 .env
 
+# lockfiles
+yarn.lock
+package_lock.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
 # axe-webdriverio
-Provides bindings for axe with webdriverio
+
+[![npm version](https://badge.fury.io/js/axe-webdriverio.svg)](https://badge.fury.io/js/axe-webdriverio)
+
+Makes WebDriver IO compatible with the [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs) package. There are four WebDriver functions that `axe-webdriverjs` uses, which need to be re-bound for WebDriverIO.
+
+- `executeScript`
+- `executeAsyncScript`
+- `switchTo`
+- `findElements`
+
+This package creates bindings for all of them.
+
+## Usage
+
+**Warning:** You must have [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs) as a peer dependency. This has changed in the latest version `1.0.0`. Previously this package installed a version of `axe-webdriverjs` that was very out of date. By using a peer dependency you can use whatever version you need while still getting the bindings.
+
+```javascript
+var AxeWebDriverIOBuilder = require("axe-webdriverio");
+const { remote } = require("webdriverio");
+
+(async () => {
+  const browser = await remote({
+    logLevel: "error",
+    path: "/",
+    capabilities: {
+      browserName: "firefox"
+    }
+  });
+
+  await browser.url("https://dequeuniversity.com/demo/mars/");
+
+  AxeWebDriverIOBuilder(browser).analyze(function(err, results) {
+    if (err) {
+      // Handle error somehow
+    }
+    console.log(results);
+  });
+
+  await browser.deleteSession();
+})().catch(e => console.error(e));
+```
+
+View the [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs) documentation for more details.
+
+### Setup
+
+```bash
+yarn
+```
+
+### Test
+
+```bash
+yarn test
+```
+
+### Types
+
+This package has types thanks to [@types/axe-webdriverjs](https://www.npmjs.com/package/@types/axe-webdriverjs). That package is an optional dependency if you use TypeScript.

--- a/package.json
+++ b/package.json
@@ -1,18 +1,22 @@
 {
   "name": "axe-webdriverio",
-  "description": "Provides a method to integrate axe with webdriverio to inject and analyze web pages using aXe",
-  "version": "0.1.0",
+  "description": "Wraps the Axe-WebDriverJS project with bindings for WebDriverIO",
+  "version": "1.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "contributors": [
     {
       "name": "Sushil Nagi",
       "url": "http://github.com/snagi"
+    },
+    {
+      "name": "Tyler Krupicka",
+      "url": "http://github.com/tylerkrupicka"
     }
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/snagi/axe-webdriverio.git"
+    "url": "https://github.com/dequelabs/axe-webdriverio.git"
   },
   "keywords": [
     "a11y",
@@ -26,13 +30,13 @@
     "webdriver",
     "webdriverio"
   ],
-  "scripts": {
-  },
+  "scripts": {},
   "peerDependencies": {
+    "axe-webdriverjs": "^2.1.0",
     "webdriverio": ">= 4.10.0"
   },
-  "devDependencies": {},
-  "dependencies": {
-    "axe-webdriverjs": "^1.2.1"
-  }
+  "devDependencies": {
+    "axe-webdriverjs": "^2.1.0"
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
A breaking change (major version) which makes `axe-webdriverjs` a peer dependency and updates documentation.

This library really is a small plugin that provides WebDriverIO bindings for `axe-webdriverjs`. Developers should have the option to use whatever version of `axe-webdriverjs` version they need with out being tied to the one stated in this package. The current version is a bit old, and most of the changes to the underlying package don't effect this plugin.

I realize that this is a breaking change, but a major version bump should avoid breaking anyone's builds. The documentation explicitly calls out that people should add the peer dependency in the future. I know some different people who copy-paste these bindings because they don't want to deal with forced `axe-webdriverjs` versions from this plugin.

This PR is kind of paired with https://github.com/dequelabs/axe-webdriverio/pull/4 and https://github.com/dequelabs/axe-webdriverio/pull/3, but I broke it apart based on feedback from maintainers. This PR may need to be updated based on conversation in those PRs.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
